### PR TITLE
Adding basic dialogflow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Superbot-807b1a9f4f85.json
 clients/whatsapp/screenshot.png
 rb_user_data/
 temp/
+Superbot-c457375bf8a5.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -519,6 +519,45 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "dialogflow": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/dialogflow/-/dialogflow-0.12.2.tgz",
+      "integrity": "sha512-Ct9NlQaYKuVlQHkvcXQXP/sWaUP0x0bjumX3R0vWiunV5biokai6WBdPVUga5AhbHnaYvBHOCKgH/zlUqSsCfQ==",
+      "requires": {
+        "google-gax": "^1.7.5",
+        "protobufjs": "^6.8.0"
+      },
+      "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "0.6.9",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.9.tgz",
+          "integrity": "sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==",
+          "requires": {
+            "semver": "^6.2.0"
+          }
+        },
+        "google-gax": {
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.7.5.tgz",
+          "integrity": "sha512-Tz2DFs8umzDcCBTi2W1cY4vEgAKaYRj70g6Hh/MiiZaJizrly7PgyxsIYUGi7sOpEuAbARQymYKvy5mNi8hEbg==",
+          "requires": {
+            "@grpc/grpc-js": "0.6.9",
+            "@grpc/proto-loader": "^0.5.1",
+            "abort-controller": "^3.0.0",
+            "duplexify": "^3.6.0",
+            "google-auth-library": "^5.0.0",
+            "is-stream-ended": "^0.1.4",
+            "lodash.at": "^4.6.0",
+            "lodash.has": "^4.5.2",
+            "node-fetch": "^2.6.0",
+            "protobufjs": "^6.8.8",
+            "retry-request": "^4.0.0",
+            "semver": "^6.0.0",
+            "walkdir": "^0.4.0"
+          }
+        }
+      }
+    },
     "dom-serializer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "axios": "^0.19.0",
     "cheerio": "^1.0.0-rc.3",
     "config": "^3.2.2",
+    "dialogflow": "^0.12.2",
     "dotenv": "^8.1.0",
     "esm": "^3.2.25",
     "express": "^4.17.1",

--- a/src/plugins/natural.js
+++ b/src/plugins/natural.js
@@ -1,17 +1,30 @@
+const dialogflow = require('dialogflow');
 
-function natural(bot, message) {
-    if (message.text == null) {
-        bot.error('Expected a text message.');
-        return;
-    }
-    if (message.text.includes('?')) {
-        bot.respond('Yes!');
-    }
-    else {
-        bot.respond('Oh, tell me more.');
-    }
-}
+let sessionClient = null;
 
 export default function(bot) {
-    bot.command('natural', natural);
+    bot.command('natural', async (bot, message) => {
+        if (!sessionClient) {
+            sessionClient = new dialogflow.SessionsClient();
+        }
+
+        const sessionPath = sessionClient.sessionPath(process.env.GOOGLE_PROJECT_ID, message.chat.id);
+        const request = {
+            session: sessionPath,
+            queryInput: {
+                text: {
+                    text: message.text,
+                    languageCode: 'en-US',
+                },
+            },
+        };
+        const responses = await sessionClient.detectIntent(request);
+        if (responses.length > 0) {
+            const result = responses[0].queryResult;        
+            bot.respond(result.fulfillmentText);
+        }
+        else {
+            bot.respond("I didn't quite get that. What do you mean?");
+        }
+    });
 }


### PR DESCRIPTION
Added basic support for Google Dialogflow through the "natural" plugin.

From Whatsapp, you can trigger this plugin using special aliases configured in ./clients/whatsapp/config/default.json.

For example:
superbot: How are you doing?

This automatically translates the request to call the "natural" command.